### PR TITLE
Order cleanup

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -74,6 +74,13 @@ class OrdersController < ApplicationController
     #@order_total = @order_products.sum { |op| op.product.price }
   end
 
+  def cleanup
+    order = Order.find(params[:id])
+    order.order_products.destroy_all
+    order.destroy
+    render json: { status: "success", message: "Order and associated products removed" }
+  end
+
   private
 
   def order_params

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -78,6 +78,8 @@ class OrdersController < ApplicationController
     order = Order.find(params[:id])
     order.order_products.destroy_all
     order.destroy
+
+    # Respond in the excepted format
     render json: { status: "success", message: "Order and associated products removed" }
   end
 


### PR DESCRIPTION
Add order cleanup endpoint for data retention compliance

Added a new cleanup endpoint to help with GDPR compliance and data retention policies. This endpoint allows removal of old order data that should no longer be retained.

Changes:
- New /cleanup endpoint for order removal
- Cascading deletion of associated order products
- JSON response for API consistency